### PR TITLE
UTF-8 encoding for serialization

### DIFF
--- a/moderatorFrontend/src/main/kotlin/webcore/NetworkManager.kt
+++ b/moderatorFrontend/src/main/kotlin/webcore/NetworkManager.kt
@@ -45,7 +45,7 @@ object NetworkManager {
   ): T? = try {
     val response: HttpResponse = client.post(url) {
       body?.let {
-        contentType(ContentType.Application.Json)
+        contentType(ContentType.Application.Json.withParameter("charset", "utf-8"))
         this.body = body // Let the Ktor client handle @Serializable classes.
       }
       urlParams.forEach { parameter(it.key, it.value) }


### PR DESCRIPTION
E.g. when creating a new guest check in umlauts were not serialized correctly due to a wrong encoding which led to not being able to check out and also having the name displayed incorrectly
<img width="988" alt="Screenshot 2022-05-25 at 12 45 37" src="https://user-images.githubusercontent.com/62036655/170245069-1fc327fb-6d4b-4de8-8298-56505fed1a3d.png">
