### PR TITLE
NavigationHandler fix

### DIFF
--- a/moderatorFrontend/src/main/kotlin/app/App.kt
+++ b/moderatorFrontend/src/main/kotlin/app/App.kt
@@ -184,6 +184,7 @@ private class App : RComponent<AppProps, AppState>() {
       allUrls = Url.values().toList(),
       dialogRef = navigationHandlerDialogRef,
       handleHistoryChange = ::handleHistoryChange,
+      getCurrentAppRoute = { state.currentAppRoute },
     )
 
     val duplicatePaths = allUrls.groupBy { it.path }.filter { it.value.count() > 1 }.keys


### PR DESCRIPTION
Hash change caused exceptions because popstate can also be triggered by a hash change and not just by navigating the history.