### PR TITLE
Fix faulty state updates

### DIFF
--- a/moderatorFrontend/src/jsMain/kotlin/views/accessManagement/accessManagementDetails/AccessManagementDetailsController.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/views/accessManagement/accessManagementDetails/AccessManagementDetailsController.kt
@@ -30,8 +30,8 @@ data class AccessManagementDetailsController(
   val accessControlNoteTextFieldValue: String,
   val accessControlReasonTextFieldValue: String,
   val timeSlots: List<ClientDateRange>,
-  val fromDateTimeSlotErrors: MutableList<TimeSlotError>,
-  val toDateTimeSlotErrors: MutableList<TimeSlotError>,
+  val fromDateTimeSlotErrors: List<TimeSlotError>,
+  val toDateTimeSlotErrors: List<TimeSlotError>,
   val personEmailTextFieldValue: String,
   val permittedPeopleList: List<String>,
   val showProgress: Boolean,
@@ -65,8 +65,8 @@ data class AccessManagementDetailsController(
       var permittedPeopleList: List<String> by useState(emptyList())
       var timeSlots: List<ClientDateRange> by useState(emptyList())
 
-      var fromDateTimeSlotErrors: MutableList<TimeSlotError> by useState(mutableListOf())
-      var toDateTimeSlotErrors: MutableList<TimeSlotError> by useState(mutableListOf())
+      var fromDateTimeSlotErrors: List<TimeSlotError> by useState(mutableListOf())
+      var toDateTimeSlotErrors: List<TimeSlotError> by useState(mutableListOf())
 
       val appContext = useContext(appContextToInject)!!
 
@@ -83,8 +83,8 @@ data class AccessManagementDetailsController(
         personEmailTextFieldValue = ""
         permittedPeopleList = accessManagement?.allowedEmails?.toList() ?: emptyList()
 
-        fromDateTimeSlotErrors = mutableListOf()
-        toDateTimeSlotErrors = mutableListOf()
+        fromDateTimeSlotErrors = listOf()
+        toDateTimeSlotErrors = listOf()
 
         val fromDate = Date().addHours(1).with(minute = 0)
         timeSlots = accessManagement?.dateRanges?.toList() ?: listOf(
@@ -176,7 +176,10 @@ data class AccessManagementDetailsController(
         timeSlots.forEach { timeSlot ->
           // End time cannot be before start time
           if (timeSlot.to < timeSlot.from) {
-            toDateTimeSlotErrors.add(TimeSlotError(text = Strings.access_control_end_date_before_start_date.get(), timeSlot = timeSlot))
+            toDateTimeSlotErrors = toDateTimeSlotErrors + TimeSlotError(
+              text = Strings.access_control_end_date_before_start_date.get(),
+              timeSlot = timeSlot,
+            )
             return false
           }
         }
@@ -185,7 +188,7 @@ data class AccessManagementDetailsController(
       }
 
       fun submitPermittedPeopleToState() {
-        permittedPeopleList += getPermittedEmailsFromTextField()
+        permittedPeopleList = permittedPeopleList + getPermittedEmailsFromTextField()
         personEmailTextFieldValue = ""
       }
 
@@ -301,8 +304,8 @@ data class AccessManagementDetailsController(
 
       fun createAccessControlOnClick(config: AccessManagementDetailsConfig) {
         // Reset errors from previous submit attempt
-        fromDateTimeSlotErrors.clear()
-        toDateTimeSlotErrors.clear()
+        fromDateTimeSlotErrors = listOf()
+        toDateTimeSlotErrors = listOf()
 
         if (validateInput()) {
           when (config) {

--- a/moderatorFrontend/src/jsMain/kotlin/views/accessManagement/accessManagementDetails/timeSlotPicker/TimeSlotPickerConfig.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/views/accessManagement/accessManagementDetails/timeSlotPicker/TimeSlotPickerConfig.kt
@@ -8,8 +8,8 @@ import kotlin.js.Date
 
 data class TimeSlotPickerConfig(
   val timeSlots: List<ClientDateRange>,
-  val fromDateTimeSlotErrors: MutableList<TimeSlotError>,
-  val toDateTimeSlotErrors: MutableList<TimeSlotError>,
+  val fromDateTimeSlotErrors: List<TimeSlotError>,
+  val toDateTimeSlotErrors: List<TimeSlotError>,
   val accessManagementDetailsType: AccessManagementDetailsConfig,
   val addTimeSlotOnClick: ButtonOnClick,
   val removeTimeSlotOnClick: (clientDateRange: ClientDateRange) -> Unit,

--- a/moderatorFrontend/src/jsMain/kotlin/webcore/MbDialog.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/webcore/MbDialog.kt
@@ -45,7 +45,7 @@ external interface MbDialogProps<T : MbDialogRef> : PropsWithRef<T>
  * UX: Ideally, only 1 dialog is present at the users context. Stacking multiple dialogs on top of each other creates easily confusing experiences.
  */
 val MbDialog = FcRefWithCoroutineScope<MbDialogProps<MbDialogRef>> { props, launch ->
-  var (configs, setConfigs) = useState(mutableListOf<DialogConfig>())
+  var (configs, setConfigs) = useState(listOf<DialogConfig>())
   // Opening a new dialog requires that the current dialog is closed before, otherwise the new dialog is closed instantly.
   // To achieve that, the onClose promise (for DialogButton::onClick in MbSingleDialog) is fulfilled after the state update of "configs",
   // which can then trigger the button onClick. Also, the user defined onClose function is executed after the "configs" state update.
@@ -63,7 +63,7 @@ val MbDialog = FcRefWithCoroutineScope<MbDialogProps<MbDialogRef>> { props, laun
         // Due to function closures, we need to use the setter function to get the current state.
         setConfigs { previousConfigs ->
           if (previousConfigs.isNotEmpty()) {
-            (previousConfigs - previousConfigs.last()).toMutableList()
+            previousConfigs - previousConfigs.last()
           } else {
             console.error("closeDialog was called although no dialog is open.")
             previousConfigs

--- a/moderatorFrontend/src/jsMain/kotlin/webcore/datePicker/DatePicker.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/webcore/datePicker/DatePicker.kt
@@ -1,132 +1,66 @@
 package webcore.datePicker
 
-import com.studo.campusqr.common.utils.LocalizedString
-import js.lazy.Lazy
-import web.cssom.*
-import js.objects.jso
+import webcore.datePicker.datePickerWithInputTypeDateSupport.DatePickerWithInputTypeDateSupport
+import webcore.datePicker.datePickerWithInputTypeDateSupport.DatePickerWithInputTypeDateSupportConfig
+import webcore.datePicker.datePickerWithoutInputTypeDateSupport.DatePickerWithoutInputTypeDateSupport
+import webcore.datePicker.datePickerWithoutInputTypeDateSupport.DatePickerWithoutInputTypeDateSupportConfig
 import mui.material.Box
-import mui.material.TextField
 import mui.system.sx
-import react.*
-import util.get
-import web.html.InputType
+import react.Props
+import web.cssom.pct
 import webcore.FcWithCoroutineScope
-import webcore.extensions.toInputTypeDateValueString
-import webcore.max
-import webcore.min
-import webcore.onChange
-import webcore.toReactNode
 
 external interface DatePickerProps : Props {
   var config: DatePickerConfig
 }
 
-@Lazy
 val DatePicker = FcWithCoroutineScope<DatePickerProps> { props, launch ->
-  val controller: DatePickerController = DatePickerController.use(config = props.config, launch = launch)
-
-  fun ChildrenBuilder.renderWithInputTypeDateSupport() {
-    TextField {
-      type = InputType.date
-      value = controller.dateTimeInputValue
-      inputProps = jso {
-        props.config.min?.let { minProp ->
-          min = minProp.toInputTypeDateValueString()
-        }
-        props.config.max?.let { maxProp ->
-          max = maxProp.toInputTypeDateValueString()
-        }
-      }
-      props.config.label?.let { label = it.toReactNode() }
-      props.config.helperText?.let { helperText = it.toReactNode() }
-      fullWidth = props.config.fullWidth
-      variant = props.config.variant
-      disabled = props.config.disabled
-      error = props.config.error || controller.fieldError
-
-      onChange = controller.newBrowsersDateTextFieldOnChange
-    }
-  }
-
-  fun ChildrenBuilder.renderWithoutInputTypeDateSupport() {
-    val dayString = LocalizedString(
-      "Day",
-      "Tag"
-    ).get()
-    val monthString = LocalizedString(
-      "Month",
-      "Monat"
-    ).get()
-    val yearString = LocalizedString(
-      "Year",
-      "Jahr"
-    ).get()
-    Box.create {
-      sx {
-        display = Display.flex
-        width = 100.pct
-      }
-      TextField {
-        fullWidth = props.config.fullWidth
-        variant = props.config.variant
-        disabled = props.config.disabled
-        error = props.config.error || controller.fieldError
-        sx {
-          flex = number(1.0)
-          paddingTop = 16.px
-        }
-        type = InputType.number
-        placeholder = dayString
-        label = dayString.toReactNode()
-        inputProps = jso {
-          min = 1
-          max = 31
-        }
-        value = controller.oldBrowsersInputValues.day
-        onChange = controller.oldBrowsersDayTextFieldOnChange
-      }
-      TextField {
-        fullWidth = props.config.fullWidth
-        variant = props.config.variant
-        disabled = props.config.disabled
-        error = props.config.error || controller.fieldError
-        sx {
-          flex = number(2.0)
-          paddingTop = 16.px
-        }
-        type = InputType.number
-        placeholder = monthString
-        label = monthString.toReactNode()
-        inputProps = jso {
-          min = 1
-          max = 12
-        }
-        value = controller.oldBrowsersInputValues.month
-        onChange = controller.oldBrowsersMonthTextFieldOnChange
-      }
-      TextField {
-        fullWidth = props.config.fullWidth
-        variant = props.config.variant
-        disabled = props.config.disabled
-        error = props.config.error || controller.fieldError
-        sx {
-          flex = number(2.0)
-          paddingTop = 16.px
-        }
-        type = InputType.number
-        placeholder = yearString
-        label = yearString.toReactNode()
-        value = controller.oldBrowsersInputValues.year
-        onChange = controller.oldBrowsersYearTextFieldOnChange
-      }
-    }
-  }
+  val controller = DatePickerController.use(launch = launch, props = props)
 
   Box {
+    if (props.config.fullWidth) {
+      sx {
+        width = 100.pct
+      }
+    }
     if (controller.detectInputDateSupport()) {
-      renderWithInputTypeDateSupport()
+      DatePickerWithInputTypeDateSupport {
+        config = DatePickerWithInputTypeDateSupportConfig(
+          date = props.config.date,
+          min = props.config.min,
+          max = props.config.max,
+          helperText = props.config.helperText,
+          label = props.config.label,
+          fullWidth = props.config.fullWidth,
+          disabled = props.config.disabled,
+          error = props.config.error,
+          onChange = props.config.onChange,
+          dateTimeInputValue = controller.dateTimeInputValue,
+          fieldError = controller.fieldError,
+          newBrowsersDateTextFieldOnChange = controller.newBrowsersDateTextFieldOnChange,
+        )
+      }
     } else {
-      renderWithoutInputTypeDateSupport()
+      DatePickerWithoutInputTypeDateSupport {
+        config = DatePickerWithoutInputTypeDateSupportConfig(
+          date = props.config.date,
+          min = props.config.min,
+          max = props.config.max,
+          helperText = props.config.helperText,
+          label = props.config.label,
+          fullWidth = props.config.fullWidth,
+          disabled = props.config.disabled,
+          error = props.config.error,
+          onChange = props.config.onChange,
+          fieldError = controller.fieldError,
+          oldBrowsersDayTextFieldOnChange = controller.oldBrowsersDayTextFieldOnChange,
+          oldBrowsersMonthTextFieldOnChange = controller.oldBrowsersMonthTextFieldOnChange,
+          oldBrowsersYearTextFieldOnChange = controller.oldBrowsersYearTextFieldOnChange,
+          tryParsingInputFields = controller.tryParsingInputFields,
+          variant = props.config.variant,
+          oldBrowsersInputValues = controller.oldBrowsersInputValues,
+        )
+      }
     }
   }
 }

--- a/moderatorFrontend/src/jsMain/kotlin/webcore/datePicker/DatePickerController.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/webcore/datePicker/DatePickerController.kt
@@ -3,9 +3,10 @@ package webcore.datePicker
 import react.useEffect
 import react.useState
 import web.dom.document
-import web.html.HTML
+import web.html.HTMLInputElement
 import webcore.Launch
 import webcore.TextFieldOnChange
+import webcore.datePicker.DatePickerConfig.DateInputValues
 import webcore.extensions.emptyToNull
 import webcore.extensions.setFullYear
 import webcore.extensions.toInputTypeDateValueString
@@ -15,34 +16,30 @@ data class DatePickerController(
   val oldBrowsersInputValues: DateInputValues,
   val dateTimeInputValue: String,
   val fieldError: Boolean,
+  val daysInMonth: (month: Int, year: Int) -> Int,
   val detectInputDateSupport: () -> Boolean,
+  val tryParsingInputFields: (dayInputValue: String, monthInputValue: String, yearInputValue: String) -> Unit,
+  val newBrowsersDateTextFieldOnChange: TextFieldOnChange,
   val oldBrowsersDayTextFieldOnChange: TextFieldOnChange,
   val oldBrowsersMonthTextFieldOnChange: TextFieldOnChange,
   val oldBrowsersYearTextFieldOnChange: TextFieldOnChange,
-  val newBrowsersDateTextFieldOnChange: TextFieldOnChange,
 ) {
   companion object {
-    fun use(config: DatePickerConfig, launch: Launch): DatePickerController {
-      val year = config.date.getFullYear()
-      val month = config.date.getMonth() + 1
-      val day = config.date.getDate()
+    fun use(launch: Launch, props: DatePickerProps): DatePickerController {
+      val year = props.config.date.getFullYear()
+      val month = props.config.date.getMonth() + 1
+      val day = props.config.date.getDate()
 
-      var dateTimeInputValue: String by useState(config.date.toInputTypeDateValueString())
       var oldBrowsersInputValues: DateInputValues by useState(DateInputValues(year.toString(), month.toString(), day.toString()))
+      var dateTimeInputValue: String by useState(props.config.date.toInputTypeDateValueString())
       var fieldError: Boolean by useState(false)
 
-      useEffect(config.date) {
-        dateTimeInputValue = config.date.toInputTypeDateValueString()
-        oldBrowsersInputValues = DateInputValues(year.toString(), month.toString(), day.toString())
-        fieldError = false
-      }
-
       fun daysInMonth(month: Int, year: Int): Int {
-        return Date(year, month, 0).getDate()
+        return Date(year, month + 1, 0).getDate() // Add 1 to the month since day = 0 gets last day of the month before
       }
 
       fun detectInputDateSupport(): Boolean {
-        val input = document.createElement(HTML.input)
+        val input = document.createElement("input") as HTMLInputElement
         input.setAttribute("type", "date")
         val invalidDateValue = "not-a-date"
         input.setAttribute("value", invalidDateValue)
@@ -51,7 +48,7 @@ data class DatePickerController(
 
       fun tryParsingInputFields(dayInputValue: String, monthInputValue: String, yearInputValue: String) {
         val now = Date()
-        var day: Int = now.getDay()
+        var day: Int = now.getDate()
         var month: Int = now.getMonth()
         var year: Int = now.getFullYear()
         var isValid: Boolean
@@ -66,53 +63,61 @@ data class DatePickerController(
         }
 
         fieldError = !isValid
+
         val date = Date().setFullYear(year, month, day)
-        config.onChange(date, isValid)
+        props.config.onChange(date, isValid)
       }
 
-      val oldBrowsersDayTextFieldOnChange: TextFieldOnChange = { event ->
-        val value = event.target.value
-        oldBrowsersInputValues.day = value
-        tryParsingInputFields(value, oldBrowsersInputValues.month, oldBrowsersInputValues.year)
-      }
-
-      val oldBrowsersMonthTextFieldOnChange: TextFieldOnChange = { event ->
-        val value = event.target.value
-        oldBrowsersInputValues.month = value
-        tryParsingInputFields(oldBrowsersInputValues.day, value, oldBrowsersInputValues.year)
-      }
-
-      val oldBrowsersYearTextFieldOnChange: TextFieldOnChange = { event ->
-        val value = event.target.value
-        oldBrowsersInputValues.year = value
-        tryParsingInputFields(oldBrowsersInputValues.day, oldBrowsersInputValues.month, value)
-      }
-
-      val newBrowsersDateTextFieldOnChange: TextFieldOnChange = { event ->
+      val datePickerWithInputTypeDateSupportOnChange: TextFieldOnChange = { event ->
         event.target.value.emptyToNull()?.let { value ->
           dateTimeInputValue = value
+
           val inputElement = event.target
           val inputDateTimestamp = inputElement.valueAsNumber
           val date = Date(inputDateTimestamp)
 
           val isValid: Boolean = !inputDateTimestamp.isNaN() && date.getFullYear() > 1000 && date.getFullYear() < 9999
-          config.onChange(date, isValid)
+          props.config.onChange(date, isValid)
           fieldError = !isValid
         }
+      }
+
+      val oldBrowsersDayTextFieldOnChange: TextFieldOnChange = { event ->
+        val value = event.target.value
+        oldBrowsersInputValues = DateInputValues(oldBrowsersInputValues.year, oldBrowsersInputValues.month, value)
+        tryParsingInputFields(value, oldBrowsersInputValues.month, oldBrowsersInputValues.year)
+      }
+
+      val oldBrowsersMonthTextFieldOnChange: TextFieldOnChange = { event ->
+        val value = event.target.value
+        oldBrowsersInputValues = DateInputValues(oldBrowsersInputValues.year, value, oldBrowsersInputValues.day)
+        tryParsingInputFields(oldBrowsersInputValues.day, value, oldBrowsersInputValues.year)
+      }
+
+      val oldBrowsersYearTextFieldOnChange: TextFieldOnChange = { event ->
+        val value = event.target.value
+        oldBrowsersInputValues = DateInputValues(value, oldBrowsersInputValues.month, oldBrowsersInputValues.day)
+        tryParsingInputFields(oldBrowsersInputValues.day, oldBrowsersInputValues.month, value)
+      }
+
+      useEffect(props.config.date) {
+        dateTimeInputValue = props.config.date.toInputTypeDateValueString()
+        oldBrowsersInputValues = DateInputValues(year.toString(), month.toString(), day.toString())
+        fieldError = false
       }
 
       return DatePickerController(
         oldBrowsersInputValues = oldBrowsersInputValues,
         dateTimeInputValue = dateTimeInputValue,
         fieldError = fieldError,
+        daysInMonth = ::daysInMonth,
         detectInputDateSupport = ::detectInputDateSupport,
+        tryParsingInputFields = ::tryParsingInputFields,
+        newBrowsersDateTextFieldOnChange = datePickerWithInputTypeDateSupportOnChange,
         oldBrowsersDayTextFieldOnChange = oldBrowsersDayTextFieldOnChange,
         oldBrowsersMonthTextFieldOnChange = oldBrowsersMonthTextFieldOnChange,
         oldBrowsersYearTextFieldOnChange = oldBrowsersYearTextFieldOnChange,
-        newBrowsersDateTextFieldOnChange = newBrowsersDateTextFieldOnChange,
       )
     }
-
-    class DateInputValues(var year: String, var month: String, var day: String)
   }
 }

--- a/moderatorFrontend/src/jsMain/kotlin/webcore/datePicker/DatePickerUtils.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/webcore/datePicker/DatePickerUtils.kt
@@ -1,0 +1,10 @@
+package webcore.datePicker
+
+import csstype.PropertiesBuilder
+import web.cssom.px
+
+object DatePickerUtils {
+  fun PropertiesBuilder.textFieldLabelStyle() {
+    paddingTop = 16.px
+  }
+}

--- a/moderatorFrontend/src/jsMain/kotlin/webcore/datePicker/datePickerInputField/DatePickerInputField.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/webcore/datePicker/datePickerInputField/DatePickerInputField.kt
@@ -1,0 +1,44 @@
+package webcore.datePicker.datePickerInputField
+
+import webcore.datePicker.DatePickerUtils.textFieldLabelStyle
+import js.objects.jso
+import mui.material.TextField
+import mui.material.textFieldClasses
+import mui.system.sx
+import react.Props
+import web.cssom.Flex
+import web.cssom.number
+import web.html.InputType
+import webcore.FcWithCoroutineScope
+import webcore.onChange
+import webcore.min
+import webcore.max
+import webcore.toReactNode
+
+external interface DatePickerInputFieldProps : Props {
+  var config: DatePickerInputFieldConfig
+}
+
+val DatePickerInputField = FcWithCoroutineScope<DatePickerInputFieldProps> { props, launch ->
+  TextField {
+    sx {
+      flex = Flex(number(1.0), number(0.0))
+      textFieldClasses.root {
+        textFieldLabelStyle()
+      }
+    }
+    type = InputType.number
+    fullWidth = props.config.fullWidth
+    disabled = props.config.disabled
+    error = props.config.error || props.config.fieldError
+    variant = props.config.variant
+    this.onChange = props.config.onChange
+    this.placeholder = props.config.placeholder
+    this.label = props.config.label.toReactNode()
+    inputProps = jso {
+      min = 1
+      max = 31
+    }
+    this.value = props.config.value
+  }
+}

--- a/moderatorFrontend/src/jsMain/kotlin/webcore/datePicker/datePickerInputField/DatePickerInputFieldConfig.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/webcore/datePicker/datePickerInputField/DatePickerInputFieldConfig.kt
@@ -1,0 +1,16 @@
+package webcore.datePicker.datePickerInputField
+
+import mui.material.FormControlVariant
+import webcore.TextFieldOnChange
+
+class DatePickerInputFieldConfig(
+  val value: String,
+  val label: String,
+  val placeholder: String = label,
+  val disabled: Boolean,
+  val error: Boolean,
+  val fullWidth: Boolean,
+  val fieldError: Boolean,
+  val variant: FormControlVariant,
+  val onChange: TextFieldOnChange,
+)

--- a/moderatorFrontend/src/jsMain/kotlin/webcore/datePicker/datePickerWithInputTypeDateSupport/DatePickerWithInputTypeDateSupport.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/webcore/datePicker/datePickerWithInputTypeDateSupport/DatePickerWithInputTypeDateSupport.kt
@@ -1,0 +1,47 @@
+package webcore.datePicker.datePickerWithInputTypeDateSupport
+
+import js.objects.jso
+import mui.material.TextField
+import mui.system.sx
+import react.Props
+import web.cssom.WhiteSpace
+import web.html.InputType
+import webcore.FcWithCoroutineScope
+import webcore.extensions.toInputTypeDateValueString
+import webcore.toReactNode
+import webcore.onChange
+import webcore.min
+import webcore.max
+
+external interface DatePickerWithInputTypeDateSupportProps : Props {
+  var config: DatePickerWithInputTypeDateSupportConfig
+}
+
+val DatePickerWithInputTypeDateSupport = FcWithCoroutineScope<DatePickerWithInputTypeDateSupportProps> { props, launch ->
+  TextField {
+    variant = props.config.variant
+    type = InputType.date
+    value = props.config.dateTimeInputValue
+    inputProps = jso {
+      props.config.min?.let { minProp ->
+        min = minProp.toInputTypeDateValueString()
+      }
+      props.config.max?.let { maxProp ->
+        max = maxProp.toInputTypeDateValueString()
+      }
+    }
+    if (props.config.helperText != null) {
+      FormHelperTextProps = jso {
+        sx {
+          whiteSpace = WhiteSpace.preLine // Handle \n
+        }
+      }
+    }
+    label = props.config.label?.toReactNode()
+    helperText = props.config.helperText?.toReactNode()
+    fullWidth = props.config.fullWidth
+    disabled = props.config.disabled
+    error = props.config.error || props.config.fieldError
+    onChange = props.config.newBrowsersDateTextFieldOnChange
+  }
+}

--- a/moderatorFrontend/src/jsMain/kotlin/webcore/datePicker/datePickerWithInputTypeDateSupport/DatePickerWithInputTypeDateSupportConfig.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/webcore/datePicker/datePickerWithInputTypeDateSupport/DatePickerWithInputTypeDateSupportConfig.kt
@@ -1,9 +1,10 @@
-package webcore.datePicker
+package webcore.datePicker.datePickerWithInputTypeDateSupport
 
 import mui.material.FormControlVariant
+import webcore.TextFieldOnChange
 import kotlin.js.Date
 
-class DatePickerConfig(
+class DatePickerWithInputTypeDateSupportConfig(
   val date: Date,
   val onChange: (date: Date, isValid: Boolean) -> Unit,
   val min: Date? = null,
@@ -14,6 +15,7 @@ class DatePickerConfig(
   val error: Boolean = false,
   val fullWidth: Boolean = false,
   val variant: FormControlVariant = FormControlVariant.standard,
-) {
-  class DateInputValues(var year: String, var month: String, var day: String)
-}
+  val dateTimeInputValue: String,
+  val fieldError: Boolean,
+  val newBrowsersDateTextFieldOnChange: TextFieldOnChange,
+)

--- a/moderatorFrontend/src/jsMain/kotlin/webcore/datePicker/datePickerWithoutInputTypeDateSupport/DatePickerWithoutInputTypeDateSupport.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/webcore/datePicker/datePickerWithoutInputTypeDateSupport/DatePickerWithoutInputTypeDateSupport.kt
@@ -1,0 +1,73 @@
+package webcore.datePicker.datePickerWithoutInputTypeDateSupport
+
+import com.studo.campusqr.common.utils.LocalizedString
+import mui.material.Box
+import mui.system.sx
+import react.ChildrenBuilder
+import react.Props
+import web.cssom.Display
+import web.cssom.pct
+import webcore.FcWithCoroutineScope
+import webcore.TextFieldOnChange
+import webcore.datePicker.datePickerInputField.DatePickerInputField
+import webcore.datePicker.datePickerInputField.DatePickerInputFieldConfig
+import util.get
+
+external interface DatePickerWithoutInputTypeDateSupportProps : Props {
+  var config: DatePickerWithoutInputTypeDateSupportConfig
+}
+
+val DatePickerWithoutInputTypeDateSupport = FcWithCoroutineScope<DatePickerWithoutInputTypeDateSupportProps> { props, launch ->
+  Box {
+    sx {
+      display = Display.flex
+      width = 100.pct
+    }
+
+    fun ChildrenBuilder.datePickerInputField(
+      value: String,
+      label: String,
+      onChange: TextFieldOnChange,
+    ) {
+      DatePickerInputField {
+        config = DatePickerInputFieldConfig(
+          value = value,
+          label = label,
+          onChange = onChange,
+          disabled = props.config.disabled,
+          error = props.config.error,
+          fullWidth = props.config.fullWidth,
+          fieldError = props.config.fieldError,
+          variant = props.config.variant,
+        )
+      }
+    }
+
+    datePickerInputField(
+      value = props.config.oldBrowsersInputValues.day,
+      label = LocalizedString(
+        "Day",
+        "Tag"
+      ).get(),
+      onChange = props.config.oldBrowsersDayTextFieldOnChange,
+    )
+
+    datePickerInputField(
+      value = props.config.oldBrowsersInputValues.month,
+      label = LocalizedString(
+        "Month",
+        "Monat"
+      ).get(),
+      onChange = props.config.oldBrowsersMonthTextFieldOnChange,
+    )
+
+    datePickerInputField(
+      value = props.config.oldBrowsersInputValues.year,
+      label = LocalizedString(
+        "Year",
+        "Jahr"
+      ).get(),
+      onChange = props.config.oldBrowsersYearTextFieldOnChange,
+    )
+  }
+}

--- a/moderatorFrontend/src/jsMain/kotlin/webcore/datePicker/datePickerWithoutInputTypeDateSupport/DatePickerWithoutInputTypeDateSupportConfig.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/webcore/datePicker/datePickerWithoutInputTypeDateSupport/DatePickerWithoutInputTypeDateSupportConfig.kt
@@ -1,0 +1,25 @@
+package webcore.datePicker.datePickerWithoutInputTypeDateSupport
+
+import mui.material.FormControlVariant
+import webcore.TextFieldOnChange
+import webcore.datePicker.DatePickerConfig.DateInputValues
+import kotlin.js.Date
+
+class DatePickerWithoutInputTypeDateSupportConfig(
+  val date: Date,
+  val onChange: (date: Date, isValid: Boolean) -> Unit,
+  val min: Date? = null,
+  val max: Date? = null,
+  val label: String? = null,
+  val helperText: String? = null,
+  val disabled: Boolean = false,
+  val error: Boolean = false,
+  val fullWidth: Boolean = false,
+  val variant: FormControlVariant = FormControlVariant.standard,
+  val oldBrowsersInputValues: DateInputValues,
+  val fieldError: Boolean,
+  val oldBrowsersDayTextFieldOnChange: TextFieldOnChange,
+  val oldBrowsersMonthTextFieldOnChange: TextFieldOnChange,
+  val oldBrowsersYearTextFieldOnChange: TextFieldOnChange,
+  val tryParsingInputFields: (dayInputValue: String, monthInputValue: String, yearInputValue: String) -> Unit,
+)

--- a/moderatorFrontend/src/jsMain/kotlin/webcore/timePicker/TimePicker.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/webcore/timePicker/TimePicker.kt
@@ -1,25 +1,13 @@
 package webcore.timePicker
 
-import com.studo.campusqr.common.utils.LocalizedString
+import com.moshbit.backend.core.ui.timePicker.TimePickerController
+import webcore.timePicker.timePickerWithInputTypeTimeSupport.TimePickerWithInputTypeTimeSupport
+import webcore.timePicker.timePickerWithInputTypeTimeSupport.TimePickerWithInputTypeTimeSupportConfig
+import webcore.timePicker.timePickerWithoutInputTypeTimeSupport.TimePickerWithoutInputTypeTimeSupport
+import webcore.timePicker.timePickerWithoutInputTypeTimeSupport.TimePickerWithoutInputTypeTimeSupportConfig
 import js.lazy.Lazy
-import web.cssom.*
-import js.objects.jso
-import mui.material.Box
-import mui.material.TextField
-import mui.system.sx
 import react.*
-import react.dom.html.ReactHTML
-import react.dom.html.ReactHTML.option
-import util.get
-import web.html.InputType
 import webcore.FcWithCoroutineScope
-import webcore.extensions.*
-import webcore.list
-import webcore.max
-import webcore.min
-import webcore.onChange
-import webcore.toReactNode
-import kotlin.js.Date
 
 external interface TimePickerProps : Props {
   var config: TimePickerConfig
@@ -27,111 +15,34 @@ external interface TimePickerProps : Props {
 
 @Lazy
 val TimePicker = FcWithCoroutineScope<TimePickerProps> { props, launch ->
-  val controller: TimePickerController = TimePickerController.use(config = props.config, launch = launch)
-
-  val stepListId = useMemo(*emptyArray<Any>()) { "timestep-list${hashCode()}" }
-
-  fun ChildrenBuilder.renderWithInputTypeTimeSupport() {
-    Box {
-      sx {
-        width = 100.pct
-      }
-      TextField {
-        value = props.config.time.toInputTypeTimeValueString()
-        inputProps = jso {
-          props.config.min?.let { minProp ->
-            min = minProp.toInputTypeTimeValueString()
-          }
-          props.config.max?.let { maxProp ->
-            max = maxProp.toInputTypeTimeValueString()
-          }
-          list = stepListId
-        }
-        label = (props.config.label ?: "").toReactNode()
-        helperText = (props.config.helperText ?: "").toReactNode()
-        fullWidth = props.config.fullWidth
-        variant = props.config.variant
-        disabled = props.config.disabled
-        error = props.config.error
-        type = InputType.time
-        onChange = controller.newBrowsersTimeTextFieldOnChange
-      }
-      if (props.config.stepMinutes != 1) { // Create time options list if step is not the default value of 1 minute
-        ReactHTML.datalist {
-          id = stepListId
-          // Control variable to fill options list
-          var timestampIterControl = Date().startOfTheDay().getTime()
-          val endOfDay = Date(timestampIterControl).endOfTheDay().getTime()
-          while (timestampIterControl <= endOfDay) {
-            option {
-              val currentDate = Date(timestampIterControl)
-              value = currentDate.getHours().toString().padStart(2, '0') + ":" +
-                  currentDate.getMinutes().toString().padStart(2, '0') // HH:mm
-            }
-            timestampIterControl += (props.config.stepMinutes * 60 * 1000) // Minutes to milliseconds
-          }
-        }
-      }
-    }
-  }
-
-  fun ChildrenBuilder.renderWithoutInputTypeTimeSupport() {
-    val hourString = LocalizedString(
-      "Hour",
-      "Stunde"
-    ).get()
-    val minuteString = LocalizedString(
-      "Minute",
-      "Minute"
-    ).get()
-    Box.create {
-      sx {
-        width = 100.pct
-      }
-      TextField {
-        fullWidth = props.config.fullWidth
-        variant = props.config.variant
-        disabled = props.config.disabled
-        error = props.config.error
-        sx {
-          flex = number(1.0)
-          paddingTop = 16.px
-        }
-        type = InputType.number
-        placeholder = hourString
-        label = hourString.toReactNode()
-        inputProps = jso {
-          min = 0
-          max = 23
-        }
-        value = controller.oldBrowsersInputValues.hour
-        this.onChange = controller.oldBrowsersHourTextFieldOnChange
-      }
-      TextField {
-        fullWidth = props.config.fullWidth
-        variant = props.config.variant
-        disabled = props.config.disabled
-        error = props.config.error
-        sx {
-          flex = number(1.0)
-          paddingTop = 16.px
-        }
-        type = InputType.number
-        placeholder = minuteString
-        label = minuteString.toReactNode()
-        inputProps = jso {
-          min = 0
-          max = 59
-        }
-        value = controller.oldBrowsersInputValues.minute
-        onChange = controller.oldBrowsersMinuteTextFieldOnChange
-      }
-    }
-  }
+  val controller = TimePickerController.use(launch = launch, props)
 
   if (controller.detectInputTimeSupport()) {
-    renderWithInputTypeTimeSupport()
+    TimePickerWithInputTypeTimeSupport {
+      config = TimePickerWithInputTypeTimeSupportConfig(
+        time = props.config.time,
+        onChange = props.config.onChange,
+        min = props.config.min,
+        max = props.config.max,
+        stepMinutes = props.config.stepMinutes,
+        disabled = props.config.disabled,
+        error = props.config.error,
+        fullWidth = props.config.fullWidth,
+        label = props.config.label,
+        helperText = props.config.helperText,
+        variant = props.config.variant,
+      )
+    }
   } else {
-    renderWithoutInputTypeTimeSupport()
+    TimePickerWithoutInputTypeTimeSupport {
+      config = TimePickerWithoutInputTypeTimeSupportConfig(
+        oldBrowsersInputValues = controller.oldBrowsersInputValues,
+        disabled = props.config.disabled,
+        error = props.config.error,
+        fullWidth = props.config.fullWidth,
+        variant = props.config.variant,
+        tryParsingInputFields = controller.tryParsingInputFields,
+      )
+    }
   }
 }

--- a/moderatorFrontend/src/jsMain/kotlin/webcore/timePicker/TimePickerConfig.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/webcore/timePicker/TimePickerConfig.kt
@@ -15,4 +15,8 @@ class TimePickerConfig(
   var label: String? = null,
   var helperText: String? = null,
   var variant: FormControlVariant = FormControlVariant.outlined,
-)
+) {
+  companion object {
+    class TimeInputValues(var hour: String, var minute: String)
+  }
+}

--- a/moderatorFrontend/src/jsMain/kotlin/webcore/timePicker/timePickerWithInputTypeTimeSupport/TimePickerWithInputTypeTimeSupport.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/webcore/timePicker/timePickerWithInputTypeTimeSupport/TimePickerWithInputTypeTimeSupport.kt
@@ -1,0 +1,88 @@
+package webcore.timePicker.timePickerWithInputTypeTimeSupport
+
+import js.lazy.Lazy
+import js.objects.jso
+import mui.material.Box
+import mui.material.TextField
+import mui.system.sx
+import react.Props
+import react.dom.html.ReactHTML
+import web.cssom.WhiteSpace
+import web.cssom.pct
+import web.html.InputType
+import kotlin.js.Date
+import webcore.FcWithCoroutineScope
+import webcore.extensions.toInputTypeTimeValueString
+import webcore.toReactNode
+import webcore.onChange
+import webcore.min
+import webcore.max
+import webcore.list
+import webcore.extensions.startOfTheDay
+import webcore.extensions.endOfTheDay
+import webcore.extensions.with
+import webcore.extensions.emptyToNull
+
+external interface TimePickerWithInputTypeTimeSupportProps : Props {
+  var config: TimePickerWithInputTypeTimeSupportConfig
+}
+
+@Lazy
+val TimePickerWithInputTypeTimeSupport = FcWithCoroutineScope<TimePickerWithInputTypeTimeSupportProps> { props, launch ->
+  val stepListId = "timestep-list${hashCode()}"
+  Box {
+    sx {
+      width = 100.pct
+    }
+    TextField {
+      variant = props.config.variant
+      value = props.config.time.toInputTypeTimeValueString()
+      inputProps = jso {
+        props.config.min?.let { minProp ->
+          min = minProp.toInputTypeTimeValueString()
+        }
+        props.config.max?.let { maxProp ->
+          max = maxProp.toInputTypeTimeValueString()
+        }
+        list = stepListId
+      }
+      if (props.config.helperText != null) {
+        FormHelperTextProps = jso {
+          sx {
+            whiteSpace = WhiteSpace.preLine // Handle \n
+          }
+        }
+      }
+      label = props.config.label?.toReactNode()
+      helperText = props.config.helperText?.toReactNode()
+      fullWidth = props.config.fullWidth
+      disabled = props.config.disabled
+      error = props.config.error
+      type = InputType.time
+      onChange = { event ->
+        event.target.value.emptyToNull()?.let { value ->
+          val hourToMinute = value.split(":").map { it.removePrefix("0").toInt() }
+          val hour = hourToMinute[0]
+          val minute = hourToMinute[1]
+          props.config.onChange(props.config.time.with(hour = hour, minute = minute))
+        }
+      }
+    }
+    if (props.config.stepMinutes != 1) { // Create time options list if step is not the default value of 1 minute
+      ReactHTML.datalist {
+        id = stepListId
+        // Control variable to fill options list
+        var timestampIterControl = Date().startOfTheDay().getTime()
+        val endOfDay = Date(timestampIterControl).endOfTheDay().getTime()
+        while (timestampIterControl <= endOfDay) {
+          ReactHTML.option {
+            val currentDate = Date(timestampIterControl)
+            value = currentDate.getHours().toString().padStart(2, '0') + ":" +
+                currentDate.getMinutes().toString().padStart(2, '0') // HH:mm
+          }
+          timestampIterControl += (props.config.stepMinutes * 60 * 1000) // Minutes to milliseconds
+        }
+      }
+    }
+  }
+}

--- a/moderatorFrontend/src/jsMain/kotlin/webcore/timePicker/timePickerWithInputTypeTimeSupport/TimePickerWithInputTypeTimeSupportConfig.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/webcore/timePicker/timePickerWithInputTypeTimeSupport/TimePickerWithInputTypeTimeSupportConfig.kt
@@ -1,0 +1,18 @@
+package webcore.timePicker.timePickerWithInputTypeTimeSupport
+
+import mui.material.FormControlVariant
+import kotlin.js.Date
+
+class TimePickerWithInputTypeTimeSupportConfig(
+  val time: Date,
+  val onChange: (date: Date) -> Unit,
+  val min: Date? = null,
+  val max: Date? = null,
+  val stepMinutes: Int = 1,
+  val disabled: Boolean = false,
+  val error: Boolean = false,
+  val fullWidth: Boolean = false,
+  val label: String? = null,
+  val helperText: String? = null,
+  val variant: FormControlVariant = FormControlVariant.standard,
+)

--- a/moderatorFrontend/src/jsMain/kotlin/webcore/timePicker/timePickerWithoutInputTypeTimeSupport/TimePickerWithoutInputTypeTimeSupport.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/webcore/timePicker/timePickerWithoutInputTypeTimeSupport/TimePickerWithoutInputTypeTimeSupport.kt
@@ -1,0 +1,82 @@
+package webcore.timePicker.timePickerWithoutInputTypeTimeSupport
+
+import com.studo.campusqr.common.utils.LocalizedString
+import js.lazy.Lazy
+import js.objects.jso
+import mui.material.BaseTextFieldProps
+import mui.material.Box
+import mui.material.TextField
+import mui.system.sx
+import react.Props
+import web.cssom.Flex
+import web.cssom.number
+import web.cssom.pct
+import web.cssom.px
+import web.html.InputType
+import webcore.FcWithCoroutineScope
+import webcore.onChange
+import webcore.min
+import webcore.max
+import util.get
+import webcore.toReactNode
+
+external interface TimePickerWithoutInputTypeTimeSupportProps : Props {
+  var config: TimePickerWithoutInputTypeTimeSupportConfig
+}
+
+@Lazy
+val TimePickerWithoutInputTypeTimeSupport = FcWithCoroutineScope<TimePickerWithoutInputTypeTimeSupportProps> { props, launch ->
+  val hourString = LocalizedString(
+    "Hour",
+    "Stunde"
+  ).get()
+  val minuteString = LocalizedString(
+    "Minute",
+    "Minute"
+  ).get()
+  Box {
+    sx {
+      width = 100.pct
+    }
+    fun BaseTextFieldProps.setCommonProps(onChange: (String) -> Unit) {
+      fullWidth = props.config.fullWidth
+      disabled = props.config.disabled
+      error = props.config.error
+      sx {
+        flex = Flex(number(1.0), number(0.0))
+        paddingTop = 16.px
+      }
+      type = InputType.number
+      this.onChange = { event ->
+        onChange(event.target.value)
+      }
+    }
+
+    TextField {
+      variant = props.config.variant
+      setCommonProps(onChange = { hour ->
+        props.config.tryParsingInputFields(hour, props.config.oldBrowsersInputValues.minute)
+      })
+      placeholder = hourString
+      label = hourString.toReactNode()
+      inputProps = jso {
+        min = 0
+        max = 23
+      }
+      value = props.config.oldBrowsersInputValues.hour
+    }
+    TextField {
+      variant = props.config.variant
+      setCommonProps(onChange = { minute ->
+        props.config.tryParsingInputFields(props.config.oldBrowsersInputValues.hour, minute)
+      })
+      placeholder = minuteString
+      label = minuteString.toReactNode()
+      inputProps = jso {
+        min = 0
+        max = 59
+      }
+      value = props.config.oldBrowsersInputValues.minute
+    }
+  }
+}

--- a/moderatorFrontend/src/jsMain/kotlin/webcore/timePicker/timePickerWithoutInputTypeTimeSupport/TimePickerWithoutInputTypeTimeSupportConfig.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/webcore/timePicker/timePickerWithoutInputTypeTimeSupport/TimePickerWithoutInputTypeTimeSupportConfig.kt
@@ -1,0 +1,13 @@
+package webcore.timePicker.timePickerWithoutInputTypeTimeSupport
+
+import mui.material.FormControlVariant
+import webcore.timePicker.TimePickerConfig
+
+class TimePickerWithoutInputTypeTimeSupportConfig(
+  val oldBrowsersInputValues: TimePickerConfig.Companion.TimeInputValues,
+  val disabled: Boolean = false,
+  val error: Boolean = false,
+  val fullWidth: Boolean = false,
+  val variant: FormControlVariant = FormControlVariant.standard,
+  val tryParsingInputFields: (hourInputValue: String, minuteInputValue: String) -> Unit,
+)


### PR DESCRIPTION
React functional components need new object references to trigger re-renderings. This means that class instances, lists and maps should never be mutated but instead be assigned new instances so that state updates work correctly. This was previously not the case with class based components.